### PR TITLE
GitHub Actions CI: Test on Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.11]
+        python-version: [3.8, 3.10]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.11]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4


### PR DESCRIPTION
Given the significant performance increase, let's ensure there are no incompatibilities.
* https://docs.python.org/3.11/whatsnew/3.11.html
> Python 3.11 is ___between 10-60% faster___ than Python 3.10. On average, we measured a 1.25x speedup on the standard benchmark suite.

___Edit:___ Python 3.11 is blocked by kivy/kivy#8042
* https://kivy.org/doc/stable/gettingstarted/installation.html -- _Kivy 2.1.0 officially supports Python versions 3.7 - 3.10._